### PR TITLE
 Add ".id" method to the SubSink

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ in your component library's `unmount`/`onDestroy` lifecycle event.
 ## Installation
 
 ```bash
-npm install subsink --save
+npm install subsink2 --save
 ```
 ## Angular examples
 
-There are 2 main ways to use the SubSink: the "easy" way and the "add/array" way.
+There are 3 main ways to use the SubSink: the "easy" way, the "add/array" way and the "id" way.
 
 > RxJS supports adding subscriptions to an array of subscriptions. You can then unsubscribe directly from that array. If this appeals to you, then feel free to use it. If you prefer the technique with SubSink using the setter (aka easy) syntax below, then use that. Either way, no judgments are made. This is entirely up to you to decide.
 
-### Easy Syntax
+### 1. Easy Syntax
 
 Example using the `sink` property to collect the subscriptions using a setter.
 
@@ -44,18 +44,16 @@ export class SomeComponent implements OnDestroy {
 }
 ```
 
-### The Array/Add Technique
+### 2. The Array/Add Technique
 
 Example using the `.add` technique. This is similar to what RxJS supports out of the box.
 
-```tsgst
+```ts
 export class SomeComponent implements OnDestroy {
   private subs = new SubSink();
 
   ...
-
   this.subs.add(observable$.subscribe(...)); 
-
   this.subs.add(observable$.subscribe(...)); 
 
   // Add multiple subscriptions at the same time
@@ -63,7 +61,26 @@ export class SomeComponent implements OnDestroy {
     observable$.subscribe(...),
     anotherObservable$.subscribe(...)
   ); 
+  ...
 
+  // Unsubscribe when the component dies
+  ngOnDestroy() {
+    this.subs.unsubscribe();
+  }
+}
+```
+
+### 3. The ID Method
+
+Example using the `id` method to collect the subscriptions.
+
+```ts
+export class SomeComponent implements OnDestroy {
+  private subs = new SubSink();
+
+  ...
+  this.subs.id('my_sub').unsubscribe();
+  this.subs.id('my_sub').sink = observable$.subscribe(...);
   ...
 
   // Unsubscribe when the component dies

--- a/README.md
+++ b/README.md
@@ -23,7 +23,34 @@ There are 3 main ways to use the SubSink: the "easy" way, the "add/array" way an
 
 > RxJS supports adding subscriptions to an array of subscriptions. You can then unsubscribe directly from that array. If this appeals to you, then feel free to use it. If you prefer the technique with SubSink using the setter (aka easy) syntax below, then use that. Either way, no judgments are made. This is entirely up to you to decide.
 
-### 1. Easy Syntax
+### 1. The ID Method
+
+Example using the `id` method to collect the subscriptions.
+
+```ts
+export class SomeComponent implements OnDestroy {
+  private subs = new SubSink();
+
+  ...
+  this.subs.id('my_sub').sink = observable$.subscribe(...);
+  // Unsubscribe by subId
+  this.subs.id('my_sub').unsubscribe();
+  ...
+  // This subscription will not be unsubscribed by "subs.unsubscribe" method.
+  // You should unsubscribe it manually.
+  this.subs.id_('my_sub2').sink = observable$.subscribe(...);
+  // Unsubscribe manually
+  this.subs.id_('my_sub2').unsubscribe();
+  ...
+
+  // Unsubscribe when the component dies
+  ngOnDestroy() {
+    this.subs.unsubscribe();
+  }
+}
+```
+
+### 2. Easy Syntax
 
 Example using the `sink` property to collect the subscriptions using a setter.
 
@@ -44,7 +71,7 @@ export class SomeComponent implements OnDestroy {
 }
 ```
 
-### 2. The Array/Add Technique
+### 3. The Array/Add Technique
 
 Example using the `.add` technique. This is similar to what RxJS supports out of the box.
 
@@ -61,27 +88,6 @@ export class SomeComponent implements OnDestroy {
     observable$.subscribe(...),
     anotherObservable$.subscribe(...)
   ); 
-  ...
-
-  // Unsubscribe when the component dies
-  ngOnDestroy() {
-    this.subs.unsubscribe();
-  }
-}
-```
-
-### 3. The ID Method
-
-Example using the `id` method to collect the subscriptions.
-
-```ts
-export class SomeComponent implements OnDestroy {
-  private subs = new SubSink();
-
-  ...
-  this.subs.id('my_sub').sink = observable$.subscribe(...);
-  // Unsubscribe by subId
-  this.subs.id('my_sub').unsubscribe();
   ...
 
   // Unsubscribe when the component dies

--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ export class SomeComponent implements OnDestroy {
   private subs = new SubSink();
 
   ...
-  this.subs.id('my_sub').unsubscribe();
   this.subs.id('my_sub').sink = observable$.subscribe(...);
+  // Unsubscribe by subId
+  this.subs.id('my_sub').unsubscribe();
   ...
 
   // Unsubscribe when the component dies

--- a/__tests__/subsink.spec.ts
+++ b/__tests__/subsink.spec.ts
@@ -31,9 +31,25 @@ describe('SubSink', () => {
     expect(mockSubscription.unsubscribe).toHaveBeenCalledTimes(1);
   });
 
-  test('unsubscribes to subscriptions added through ".id" method accessor', () => {
+  test('unsubscribes to subscriptions added through ".id" method accessor1', () => {
     subs.id('my_sub').sink = mockSubscription;
     subs.id('my_sub').unsubscribe();
+  
+    expect(mockSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  test('unsubscribes to subscriptions added through ".id" method accessor2', () => {
+    subs.id('my_sub').sink = mockSubscription;
+    subs.id('my_sub').unsubscribe();
+    subs.unsubscribe();
+  
+    expect(mockSubscription.unsubscribe).toHaveBeenCalledTimes(2);
+  });
+  
+  test('unsubscribes to subscriptions added through ".id_" method accessor', () => {
+    subs.id_('my_sub').sink = mockSubscription;
+    subs.id_('my_sub').unsubscribe();
+    subs.unsubscribe();
   
     expect(mockSubscription.unsubscribe).toHaveBeenCalledTimes(1);
   });

--- a/__tests__/subsink.spec.ts
+++ b/__tests__/subsink.spec.ts
@@ -32,7 +32,6 @@ describe('SubSink', () => {
   });
 
   test('unsubscribes to subscriptions added through ".id" method accessor', () => {
-    subs.id('my_sub').unsubscribe();
     subs.id('my_sub').sink = mockSubscription;
     subs.id('my_sub').unsubscribe();
   

--- a/__tests__/subsink.spec.ts
+++ b/__tests__/subsink.spec.ts
@@ -3,7 +3,7 @@ import { SubSink, SubscriptionLike } from '../src/subsink';
 describe('SubSink', () => {
   let mockSubscription: SubscriptionLike;
   let mockSubscription2: SubscriptionLike;
-  let sink: SubSink;
+  let subs: SubSink;
   
   beforeEach(() => {
     mockSubscription = {
@@ -13,38 +13,46 @@ describe('SubSink', () => {
       unsubscribe: jest.fn()
     };
   
-    sink = new SubSink();
+    subs = new SubSink();
   })
   
   
   test('unsubscribes to subscriptions added through method', () => {
-    sink.add(mockSubscription);
-    sink.unsubscribe();
+    subs.add(mockSubscription);
+    subs.unsubscribe();
   
     expect(mockSubscription.unsubscribe).toHaveBeenCalledTimes(1);
   });
   
   test('unsubscribes to subscriptions added through property accessor', () => {
-    sink.sink = mockSubscription;
-    sink.unsubscribe();
+    subs.sink = mockSubscription;
+    subs.unsubscribe();
+  
+    expect(mockSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  test('unsubscribes to subscriptions added through ".id" method accessor', () => {
+    subs.id('my_sub').unsubscribe();
+    subs.id('my_sub').sink = mockSubscription;
+    subs.id('my_sub').unsubscribe();
   
     expect(mockSubscription.unsubscribe).toHaveBeenCalledTimes(1);
   });
   
   test('unsubscribes from subscription only once', () => {
-    sink.sink = mockSubscription;
+    subs.sink = mockSubscription;
   
-    sink.unsubscribe();
-    sink.unsubscribe();
+    subs.unsubscribe();
+    subs.unsubscribe();
   
     expect(mockSubscription.unsubscribe).toHaveBeenCalledTimes(1);
   });
   
   test('unsubscribes from subscription only once', () => {
-    sink.sink = mockSubscription;
-    sink.sink = mockSubscription2;
+    subs.sink = mockSubscription;
+    subs.sink = mockSubscription2;
   
-    sink.unsubscribe();
+    subs.unsubscribe();
   
     expect(mockSubscription.unsubscribe).toHaveBeenCalledTimes(1);
     expect(mockSubscription2.unsubscribe).toHaveBeenCalledTimes(1);
@@ -52,23 +60,23 @@ describe('SubSink', () => {
   
   describe('does throw exception given SubscriptionLike is', () => {
     test('undefined', () => {
-      sink.add(undefined);
-      expect(() => sink.unsubscribe()).not.toThrow();
+      subs.add(undefined);
+      expect(() => subs.unsubscribe()).not.toThrow();
     });
   
     test('null', () => {
-      sink.add(null);
-      expect(() => sink.unsubscribe()).not.toThrow();
+      subs.add(null);
+      expect(() => subs.unsubscribe()).not.toThrow();
     });
   
     test('not a SubscriptionLike', () => {
-      sink.add({} as any);
-      expect(() => sink.unsubscribe()).not.toThrow();
+      subs.add({} as any);
+      expect(() => subs.unsubscribe()).not.toThrow();
     });
   
     test('containing a non function member with name unsubscribe', () => {
-      sink.add({unsubscribe: '1'} as any);
-      expect(() => sink.unsubscribe()).not.toThrow();
+      subs.add({unsubscribe: '1'} as any);
+      expect(() => subs.unsubscribe()).not.toThrow();
     });
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "subsink",
+  "name": "subsink2",
   "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subsink2",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "main": "dist/index.js",
   "es2015": "dist/es2015/index.js",
   "description": "RxJS subscription sink for unsubscribing gracefully in a component",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subsink2",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "es2015": "dist/es2015/index.js",
   "description": "RxJS subscription sink for unsubscribing gracefully in a component",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "subsink",
-  "version": "1.0.2",
+  "name": "subsink2",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "es2015": "dist/es2015/index.js",
   "description": "RxJS subscription sink for unsubscribing gracefully in a component",
@@ -27,10 +27,11 @@
   ],
   "typings": "./dist/index.d.ts",
   "maintainers": [
-    "Ward Bell"
+    "Ward Bell",
+    "CN-Tower"
   ],
   "repository": {
-    "url": "https://github.com/wardbell/subsink"
+    "url": "https://github.com/CN-Tower/subsink2"
   },
   "devDependencies": {
     "@types/jest": "^21.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subsink2",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "dist/index.js",
   "es2015": "dist/es2015/index.js",
   "description": "RxJS subscription sink for unsubscribing gracefully in a component",

--- a/src/subsink.ts
+++ b/src/subsink.ts
@@ -27,8 +27,9 @@ export class SubSink {
    *   this.subs.sink = observable$.subscribe(...)
    *   this.subs.add(observable$.subscribe(...));
    *   ...
-   *   this.subs.id('my_sub').unsubscribe();
    *   this.subs.id('my_sub').sink = observable$.subscribe(...);
+   *   // Unsubscribe by subId
+   *   this.subs.id('my_sub').unsubscribe();
    *   ...
    *   ngOnDestroy() {
    *     this.subs.unsubscribe();
@@ -58,16 +59,17 @@ export class SubSink {
   /**
    * Tracke subscriptions by subId
    * @example
-   *  this.subs.id('my_sub').unsubscribe();
    *  this.subs.id('my_sub').sink = observable$.subscribe(...);
+   *  // Unsubscribe by subId
+   *  this.subs.id('my_sub').unsubscribe();
    */
-  id(subId: string) {
+  id(subId: string, isKeepPrev: boolean = false) {
     const subSink: SubscriptionLike = {
       unsubscribe: () => this.unsub(subId),
     };
     Object.defineProperty(subSink, 'sink', {
       set: (subscription: Nullable<SubscriptionLike>) => {
-        this.unsub(subId);
+        if (!isKeepPrev) this.unsub(subId);
         this._subx[subId] = subscription;
       },
       enumerable: true,


### PR DESCRIPTION
```typescript
export class SomeComponent implements OnDestroy {
    private subs = new SubSink();

    ngOnInit() {
        // Original Methods
        this.subs.sink = observable$.subscribe(...);
        this.subs.add(observable$.subscribe(...));

        // Subscribe by ID
        this.subs.id('sub1').sink = observable$.subscribe(...);
        this.subs.id('sub2').sink = observable$.subscribe(...);

        // Unsubscribe by ID
        this.subs.id('sub1').unsubscribe();

        // This subscription will not be unsubscribed by "subs.unsubscribe" method.
        // You should unsubscribe it manually.
        this.subs.id_('sub3').sink = observable$.subscribe(...);

        // Unsubscribe manually
        this.subs.id_('sub3').unsubscribe();
    }

    // Unsubscribe all the subs except `.id_` subs  when the component dies
    ngOnDestroy() {
        this.subs.unsubscribe();
    }
}
```